### PR TITLE
Fix link to accept-language-parser repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Hapi plugin for automagically parsing the accept-language header, and populating request.pre.language.
 
-Uses the [accept-language-parser](opentable/accept-language-parser) module under the hood
+Uses the [accept-language-parser](//github.com/opentable/accept-language-parser) module under the hood
 
 installation:
 


### PR DESCRIPTION
Previously the link was relative to a file in this repo, not a github url.